### PR TITLE
remove reference of micro within function

### DIFF
--- a/R/ectotherm.R
+++ b/R/ectotherm.R
@@ -784,7 +784,7 @@ ectotherm <- function(
   ndays <- length(rainfall) # get number of days of simulation
 
   # error trapping
-  if(micro$metout[1,2] != 0){
+  if(metout[1,2] != 0){
     message("error: microclimate input must start at midnight (TIME = 0) - check your microclimate input \n")
     errors<-1
   }


### PR DESCRIPTION
This is to aid in function stack calls, especially those that might be used to parallelize MNM code